### PR TITLE
Fix moving when should not

### DIFF
--- a/absolute_mouse/__init__.py
+++ b/absolute_mouse/__init__.py
@@ -109,7 +109,7 @@ class Mouse:
         """
         Place the mouse at the indicated position and turn the mouse wheel.
         Moves to the coordinates before wheeling.
-        Does not move the mouse if x and y are not provided or None.
+        Does not move the mouse if x and y are not provided or ``None``.
 
         :param x: Set pointer on x axis. 32767 = 100% to the right
         :param y: Set pointer on y axis. 32767 = 100% to the bottom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,6 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
         import sphinx_rtd_theme
 
         html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
     except:
         html_theme = "default"
         html_theme_path = ["."]


### PR DESCRIPTION
Don't change the x/y positions when sending anything else.
Allow for moving the wheel only.
Don't do a "noop" test in `__init__` since it wouldn't be one, it would move the mouse to `(0,0)`.
Fixes #1  